### PR TITLE
ci: upgrade Go to 1.22

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,6 @@ jobs:
 
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
 
       - run: make test

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.21.3
+golang 1.22.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pomerium/enterprise-client-go
 
-go 1.21
+go 1.22
 
 require (
 	github.com/envoyproxy/go-control-plane v0.12.0


### PR DESCRIPTION
Upgrades Go to 1.22

Related: https://github.com/pomerium/internal/issues/1731

